### PR TITLE
Add assistant grid and search shortcodes with category support

### DIFF
--- a/assets/css/agent-grid.css
+++ b/assets/css/agent-grid.css
@@ -1,0 +1,13 @@
+.am-agent-search-wrap{margin-bottom:1rem;text-align:center;}
+.am-agent-search{width:100%;max-width:400px;padding:8px 12px;border:1px solid #ccc;border-radius:8px;}
+.am-agent-section{margin-bottom:24px;}
+.am-agent-section-title{margin:0 0 8px;font-size:1.2em;}
+.am-agent-row{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px;}
+.am-agent-card{flex:0 0 auto;display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;background:#fff;border-radius:12px;padding:8px 12px;box-shadow:0 1px 2px rgba(0,0,0,0.1);}
+.am-agent-card img{width:48px;height:48px;border-radius:50%;object-fit:cover;}
+.am-agent-card-meta{display:flex;flex-direction:column;}
+.am-agent-name{font-weight:600;}
+.am-agent-subtitle{font-size:0.85em;color:#555;}
+.am-agent-tabs{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-top:24px;}
+.am-agent-tab{padding:6px 12px;border:none;border-radius:12px;background:#eee;cursor:pointer;}
+.am-agent-tab:hover{background:#ddd;}

--- a/assets/js/agent-grid.js
+++ b/assets/js/agent-grid.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded',function(){
+  function filterCards(q){
+    q=q.toLowerCase();
+    document.querySelectorAll('.am-agent-card').forEach(function(card){
+      var match=card.dataset.search.indexOf(q)!==-1;
+      card.style.display=match?'':'none';
+    });
+    document.querySelectorAll('.am-agent-section').forEach(function(sec){
+      var any=Array.from(sec.querySelectorAll('.am-agent-card')).some(function(c){return c.style.display!=="none";});
+      sec.style.display=any?'':'none';
+    });
+  }
+  document.querySelectorAll('.am-agent-search').forEach(function(inp){
+    inp.addEventListener('input',function(){filterCards(inp.value);});
+  });
+  document.querySelectorAll('.am-agent-tab').forEach(function(btn){
+    btn.addEventListener('click',function(){
+      var id=btn.dataset.target;
+      var el=document.getElementById(id);
+      if(el){el.scrollIntoView({behavior:'smooth'});} });
+  });
+});

--- a/includes/cpt-agent.php
+++ b/includes/cpt-agent.php
@@ -7,7 +7,16 @@ add_action('init', function(){
     'public' => false,
     'show_ui' => true,
     'supports' => ['title','thumbnail'],
+    'taxonomies' => ['am_agent_category'],
     'menu_icon' => 'dashicons-buddicons-buddypress-logo'
+  ]);
+
+  register_taxonomy('am_agent_category','am_agent',[
+    'label' => 'Agent Categories',
+    'public' => false,
+    'show_ui' => true,
+    'show_admin_column' => true,
+    'hierarchical' => false,
   ]);
 });
 
@@ -20,7 +29,6 @@ function am_agent_meta_box_cb($post){
   $prompt  = get_post_meta($post->ID,'am_system_prompt',true);
   $model   = get_post_meta($post->ID,'am_model',true) ?: AM_OPENAI_MODEL;
   $voice   = get_post_meta($post->ID,'am_voice_id',true);
-  $avatar  = get_post_meta($post->ID,'am_avatar_url',true);
   $temp    = get_post_meta($post->ID,'am_temperature',true);
   $subtitle= get_post_meta($post->ID,'am_subtitle',true); // “Character ready to chat” per-agent
   $complement = get_post_meta($post->ID,'am_complement',true);
@@ -42,8 +50,6 @@ function am_agent_meta_box_cb($post){
     <input type="number" step="0.01" min="0" max="2" name="am_temperature" value="<?php echo esc_attr($temp); ?>" style="width:120px"></label></div>
   <div class="am-field"><label><strong>Voice ID (ElevenLabs)</strong><br>
     <input type="text" name="am_voice_id" value="<?php echo esc_attr($voice); ?>" style="width:100%"></label></div>
-  <div class="am-field"><label><strong>Avatar URL</strong><br>
-    <input type="text" name="am_avatar_url" value="<?php echo esc_attr($avatar); ?>" style="width:100%"></label></div>
   <div class="am-field"><label><strong>Banned words (per-agent)</strong><br>
     <textarea name="am_banned_words_agent" placeholder="one word per line"><?php echo esc_textarea($banA); ?></textarea></label></div>
 <?php }
@@ -57,7 +63,6 @@ add_action('save_post_am_agent', function($post_id){
   $t = max(0, min(2, $t));
   update_post_meta($post_id,'am_temperature',$t);
   update_post_meta($post_id,'am_voice_id',sanitize_text_field($_POST['am_voice_id'] ?? ''));
-  update_post_meta($post_id,'am_avatar_url',esc_url_raw($_POST['am_avatar_url'] ?? ''));
   update_post_meta($post_id,'am_subtitle',sanitize_text_field($_POST['am_subtitle'] ?? ''));
   update_post_meta($post_id,'am_complement',sanitize_text_field($_POST['am_complement'] ?? ''));
   update_post_meta($post_id,'am_banned_words_agent',sanitize_textarea_field($_POST['am_banned_words_agent'] ?? ''));


### PR DESCRIPTION
## Summary
- add `am_agent_category` taxonomy and remove avatar URL field, relying on featured images
- provide new `[am_agent_grid]` and `[am_agent_search]` shortcodes with responsive layout and filtering
- replace legacy avatar meta usage with post thumbnails across shortcodes

## Testing
- `php -l includes/cpt-agent.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_b_68b9256b42f8832497e35cd9689ffd84