### PR TITLE
Improve agent card UI and search

### DIFF
--- a/assets/css/agent-grid.css
+++ b/assets/css/agent-grid.css
@@ -1,13 +1,14 @@
 .am-agent-search-wrap{margin-bottom:1rem;text-align:center;}
-.am-agent-search{width:100%;max-width:400px;padding:8px 12px;border:1px solid #ccc;border-radius:8px;}
+.am-agent-search{width:100%;max-width:400px;border:none;border-radius:40px;background-color:#F5E9F5;outline:none;padding:8px 12px;padding-left:45px;}
 .am-agent-section{margin-bottom:24px;}
 .am-agent-section-title{margin:0 0 8px;font-size:1.2em;}
 .am-agent-row{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px;}
-.am-agent-card{flex:0 0 auto;display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit;background:#fff;border-radius:12px;padding:8px 12px;box-shadow:0 1px 2px rgba(0,0,0,0.1);}
-.am-agent-card img{width:48px;height:48px;border-radius:50%;object-fit:cover;}
+.am-agent-card{flex:0 0 auto;display:flex;align-items:flex-start;gap:16px;text-decoration:none;color:inherit;background:#F5E9F5;border-radius:20px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.am-agent-card img{width:72px;height:72px;border-radius:16px;object-fit:cover;}
 .am-agent-card-meta{display:flex;flex-direction:column;}
-.am-agent-name{font-weight:600;}
-.am-agent-subtitle{font-size:0.85em;color:#555;}
-.am-agent-tabs{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-top:24px;}
+.am-agent-name{font-weight:600;font-size:1.1em;}
+.am-agent-subtitle{font-size:0.9em;color:#6B5AEA;margin-top:4px;}
+.am-agent-complement{font-size:0.9em;color:#555;margin-top:8px;}
+.am-agent-tabs{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-bottom:24px;}
 .am-agent-tab{padding:6px 12px;border:none;border-radius:12px;background:#eee;cursor:pointer;}
 .am-agent-tab:hover{background:#ddd;}

--- a/assets/js/agent-grid.js
+++ b/assets/js/agent-grid.js
@@ -1,8 +1,9 @@
 document.addEventListener('DOMContentLoaded',function(){
   function filterCards(q){
-    q=q.toLowerCase();
+    q=String(q||'').toLowerCase();
     document.querySelectorAll('.am-agent-card').forEach(function(card){
-      var match=card.dataset.search.indexOf(q)!==-1;
+      var data=card.dataset.search||'';
+      var match=data.indexOf(q)!==-1;
       card.style.display=match?'':'none';
     });
     document.querySelectorAll('.am-agent-section').forEach(function(sec){
@@ -12,6 +13,7 @@ document.addEventListener('DOMContentLoaded',function(){
   }
   document.querySelectorAll('.am-agent-search').forEach(function(inp){
     inp.addEventListener('input',function(){filterCards(inp.value);});
+    filterCards(inp.value);
   });
   document.querySelectorAll('.am-agent-tab').forEach(function(btn){
     btn.addEventListener('click',function(){

--- a/includes/cpt-agent.php
+++ b/includes/cpt-agent.php
@@ -7,12 +7,20 @@ add_action('init', function(){
     'public' => false,
     'show_ui' => true,
     'supports' => ['title','thumbnail'],
-    'taxonomies' => ['am_agent_category'],
+    'taxonomies' => ['am_agent_category','am_agent_tag'],
     'menu_icon' => 'dashicons-buddicons-buddypress-logo'
   ]);
 
   register_taxonomy('am_agent_category','am_agent',[
     'label' => 'Agent Categories',
+    'public' => false,
+    'show_ui' => true,
+    'show_admin_column' => true,
+    'hierarchical' => false,
+  ]);
+
+  register_taxonomy('am_agent_tag','am_agent',[
+    'label' => 'Agent Tags',
     'public' => false,
     'show_ui' => true,
     'show_admin_column' => true,


### PR DESCRIPTION
## Summary
- Style agent cards and search bar to match design
- Add agent tag taxonomy and include categories, tags and quotes in search
- Fix category query and reorder tabs to show assigned agents

## Testing
- `php -l includes/cpt-agent.php`
- `php -l includes/shortcodes.php`
- `node --check assets/js/agent-grid.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9571bf33c8324a3a488e534ed94a2