### PR TITLE
Use tags for agent tabs and refine card layout

### DIFF
--- a/assets/css/agent-grid.css
+++ b/assets/css/agent-grid.css
@@ -1,14 +1,16 @@
 .am-agent-search-wrap{margin-bottom:1rem;text-align:center;}
 .am-agent-search{width:100%;max-width:400px;border:none;border-radius:40px;background-color:#F5E9F5;outline:none;padding:8px 12px;padding-left:45px;}
-.am-agent-section{margin-bottom:24px;}
+.am-agent-section{display:none;margin-bottom:24px;}
+.am-agent-section.active{display:block;}
 .am-agent-section-title{margin:0 0 8px;font-size:1.2em;}
-.am-agent-row{display:flex;gap:12px;overflow-x:auto;padding-bottom:6px;}
-.am-agent-card{flex:0 0 auto;display:flex;align-items:flex-start;gap:16px;text-decoration:none;color:inherit;background:#F5E9F5;border-radius:20px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.am-agent-row{display:flex;flex-wrap:wrap;gap:16px;}
+.am-agent-card{flex:1 1 240px;max-width:260px;min-height:150px;display:flex;align-items:flex-start;gap:16px;text-decoration:none;color:inherit;background:#F5E9F5;border-radius:20px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .am-agent-card img{width:72px;height:72px;border-radius:16px;object-fit:cover;}
 .am-agent-card-meta{display:flex;flex-direction:column;}
 .am-agent-name{font-weight:600;font-size:1.1em;}
 .am-agent-subtitle{font-size:0.9em;color:#6B5AEA;margin-top:4px;}
 .am-agent-complement{font-size:0.9em;color:#555;margin-top:8px;}
-.am-agent-tabs{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-bottom:24px;}
+.am-agent-tabs{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-top:24px;}
 .am-agent-tab{padding:6px 12px;border:none;border-radius:12px;background:#eee;cursor:pointer;}
+.am-agent-tab.active{background:#ddd;}
 .am-agent-tab:hover{background:#ddd;}

--- a/assets/js/agent-grid.js
+++ b/assets/js/agent-grid.js
@@ -1,24 +1,31 @@
 document.addEventListener('DOMContentLoaded',function(){
   function filterCards(q){
     q=String(q||'').toLowerCase();
-    document.querySelectorAll('.am-agent-card').forEach(function(card){
+    var active=document.querySelector('.am-agent-section.active');
+    if(!active) return;
+    active.querySelectorAll('.am-agent-card').forEach(function(card){
       var data=card.dataset.search||'';
       var match=data.indexOf(q)!==-1;
       card.style.display=match?'':'none';
-    });
-    document.querySelectorAll('.am-agent-section').forEach(function(sec){
-      var any=Array.from(sec.querySelectorAll('.am-agent-card')).some(function(c){return c.style.display!=="none";});
-      sec.style.display=any?'':'none';
     });
   }
   document.querySelectorAll('.am-agent-search').forEach(function(inp){
     inp.addEventListener('input',function(){filterCards(inp.value);});
     filterCards(inp.value);
   });
+  function activateTab(id){
+    document.querySelectorAll('.am-agent-tab').forEach(function(btn){
+      btn.classList.toggle('active',btn.dataset.target===id);
+    });
+    document.querySelectorAll('.am-agent-section').forEach(function(sec){
+      sec.classList.toggle('active',sec.id===id);
+    });
+    var search=document.querySelector('.am-agent-search');
+    if(search) filterCards(search.value);
+  }
   document.querySelectorAll('.am-agent-tab').forEach(function(btn){
-    btn.addEventListener('click',function(){
-      var id=btn.dataset.target;
-      var el=document.getElementById(id);
-      if(el){el.scrollIntoView({behavior:'smooth'});} });
+    btn.addEventListener('click',function(){activateTab(btn.dataset.target);});
   });
+  var first=document.querySelector('.am-agent-tab');
+  if(first) activateTab(first.dataset.target);
 });

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -926,23 +926,23 @@ function am_agent_grid_shortcode(){
   wp_enqueue_style('am-agent-grid', AM_CA_PLUGIN_URL.'assets/css/agent-grid.css', [], AM_CA_VERSION);
   wp_enqueue_script('am-agent-grid', AM_CA_PLUGIN_URL.'assets/js/agent-grid.js', [], AM_CA_VERSION, true);
 
-  $terms = get_terms(['taxonomy'=>'am_agent_category','hide_empty'=>true]);
+  $terms = get_terms(['taxonomy'=>'am_agent_tag','hide_empty'=>true]);
   $tabs = [];
   $sections_html = '';
+  $first = true;
   foreach($terms as $t){
     $agents = get_posts([
       'post_type' => 'am_agent',
       'numberposts' => -1,
       'tax_query' => [[
-        'taxonomy' => 'am_agent_category',
+        'taxonomy' => 'am_agent_tag',
         'terms' => [$t->term_id],
       ]],
       'orderby' => 'title',
       'order' => 'ASC'
     ]);
     if(!$agents) continue;
-    $sections_html .= '<section id="am-agent-section-'.esc_attr($t->term_id).'" class="am-agent-section">';
-    $sections_html .= '<h3 class="am-agent-section-title">'.esc_html($t->name).'</h3>';
+    $sections_html .= '<section id="am-agent-section-'.esc_attr($t->term_id).'" class="am-agent-section'.($first?' active':'').'">';
     $sections_html .= '<div class="am-agent-row">';
     foreach($agents as $a){
       $name = get_the_title($a);
@@ -963,9 +963,11 @@ function am_agent_grid_shortcode(){
     }
     $sections_html .= '</div></section>';
     $tabs[] = ['id'=>$t->term_id,'name'=>$t->name];
+    $first = false;
   }
   ob_start();
   echo '<div class="am-agent-grid-wrapper">';
+  echo $sections_html;
   if($tabs){
     echo '<div class="am-agent-tabs">';
     foreach($tabs as $tab){
@@ -973,7 +975,6 @@ function am_agent_grid_shortcode(){
     }
     echo '</div>';
   }
-  echo $sections_html;
   echo '</div>';
   return ob_get_clean();
 }


### PR DESCRIPTION
## Summary
- build agent grid tabs from tags instead of categories and place tabs below card grid
- standardize agent card layout
- add JS logic to activate tabs and filter search within active tag

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/agent-grid.js`


------
https://chatgpt.com/codex/tasks/task_b_68b95a196c948324a418d2a9cddb7b16