### PR TITLE
Improve agent grid layout and tag filtering

### DIFF
--- a/assets/css/agent-grid.css
+++ b/assets/css/agent-grid.css
@@ -1,10 +1,9 @@
 .am-agent-search-wrap{margin-bottom:1rem;text-align:center;}
 .am-agent-search{width:100%;max-width:400px;border:none;border-radius:40px;background-color:#F5E9F5;outline:none;padding:8px 12px;padding-left:45px;}
-.am-agent-section{display:none;margin-bottom:24px;}
-.am-agent-section.active{display:block;}
+.am-agent-section{margin-bottom:24px;}
 .am-agent-section-title{margin:0 0 8px;font-size:1.2em;}
 .am-agent-row{display:flex;flex-wrap:wrap;gap:16px;}
-.am-agent-card{flex:1 1 240px;max-width:260px;min-height:150px;display:flex;align-items:flex-start;gap:16px;text-decoration:none;color:inherit;background:#F5E9F5;border-radius:20px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.am-agent-card{flex:0 0 220px;max-width:220px;min-height:150px;display:flex;align-items:flex-start;gap:16px;text-decoration:none;color:inherit;background:#F5E9F5;border-radius:20px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .am-agent-card img{width:72px;height:72px;border-radius:16px;object-fit:cover;}
 .am-agent-card-meta{display:flex;flex-direction:column;}
 .am-agent-name{font-weight:600;font-size:1.1em;}

--- a/assets/js/agent-grid.js
+++ b/assets/js/agent-grid.js
@@ -1,31 +1,37 @@
 document.addEventListener('DOMContentLoaded',function(){
-  function filterCards(q){
-    q=String(q||'').toLowerCase();
-    var active=document.querySelector('.am-agent-section.active');
-    if(!active) return;
-    active.querySelectorAll('.am-agent-card').forEach(function(card){
+  var currentTag='all';
+
+  function applyFilters(){
+    var q=String(document.querySelector('.am-agent-search')?.value||'').toLowerCase();
+    document.querySelectorAll('.am-agent-card').forEach(function(card){
       var data=card.dataset.search||'';
-      var match=data.indexOf(q)!==-1;
-      card.style.display=match?'':'none';
-    });
-  }
-  document.querySelectorAll('.am-agent-search').forEach(function(inp){
-    inp.addEventListener('input',function(){filterCards(inp.value);});
-    filterCards(inp.value);
-  });
-  function activateTab(id){
-    document.querySelectorAll('.am-agent-tab').forEach(function(btn){
-      btn.classList.toggle('active',btn.dataset.target===id);
+      var tags=card.dataset.tags||'';
+      var matchSearch=data.indexOf(q)!==-1;
+      var matchTag=currentTag==='all'||tags.indexOf(currentTag)!==-1;
+      card.style.display=(matchSearch&&matchTag)?'':'none';
     });
     document.querySelectorAll('.am-agent-section').forEach(function(sec){
-      sec.classList.toggle('active',sec.id===id);
+      var visible=Array.from(sec.querySelectorAll('.am-agent-card')).some(function(card){
+        return card.style.display!=="none";
+      });
+      sec.style.display=visible?'':'none';
     });
-    var search=document.querySelector('.am-agent-search');
-    if(search) filterCards(search.value);
   }
-  document.querySelectorAll('.am-agent-tab').forEach(function(btn){
-    btn.addEventListener('click',function(){activateTab(btn.dataset.target);});
+
+  document.querySelectorAll('.am-agent-search').forEach(function(inp){
+    inp.addEventListener('input',applyFilters);
   });
-  var first=document.querySelector('.am-agent-tab');
-  if(first) activateTab(first.dataset.target);
+
+  document.querySelectorAll('.am-agent-tab').forEach(function(btn){
+    btn.addEventListener('click',function(){
+      currentTag=btn.dataset.tag;
+      document.querySelectorAll('.am-agent-tab').forEach(function(b){
+        b.classList.toggle('active',b===btn);
+      });
+      applyFilters();
+    });
+  });
+
+  applyFilters();
 });
+


### PR DESCRIPTION
## Summary
- Display agent categories sequentially in a fixed order
- Show uniform agent cards and tag filter tabs at the bottom
- Add tag-based card filtering logic in JavaScript

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/agent-grid.js`


------
https://chatgpt.com/codex/tasks/task_b_68b969a4a03c8324a8dd2ab04cb2ac1d